### PR TITLE
Ensure that detection passes when only a pyproject.toml file is present.

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -42,13 +42,18 @@ func Detect() packit.DetectFunc {
 			return packit.DetectResult{}, packit.Fail.WithMessage("failed trying to stat package-list.txt: %w", err)
 		}
 
+		pyprojectTOMLFile, err := fs.Exists(filepath.Join(context.WorkingDir, "pyproject.toml"))
+		if err != nil {
+			return packit.DetectResult{}, packit.Fail.WithMessage("failed trying to stat pyproject.toml: %w", err)
+		}
+
 		pythonFiles, err := filepath.Glob(filepath.Join(context.WorkingDir, "*.py"))
 		if err != nil {
 			return packit.DetectResult{}, packit.Fail.WithMessage("failed trying to find *.py files: %w", err)
 		}
 
-		if !envFile && !lockFile && len(pythonFiles) < 1 {
-			return packit.DetectResult{}, packit.Fail.WithMessage("No *.py, environment.yml or package-list.txt found")
+		if !envFile && !lockFile && !pyprojectTOMLFile && len(pythonFiles) < 1 {
+			return packit.DetectResult{}, packit.Fail.WithMessage("No *.py, environment.yml, pyproject.toml, or package-list.txt found")
 		}
 
 		simplePlan := packit.BuildPlan{


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

Currently a poetry app (or any app using a `pyproject.toml` file) will fail detection if there are no python files in the working directory. We should explicitly check for the presence of `pyproject.toml` as we should support this case.

I also backfilled some missing unit tests ensuring that detection passes in the other cases where there are no `*.py` files in the working directory but there are valid files like `package-list.txt`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
