### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.8"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/python-start"
   id = "paketo-buildpacks/python-start"
-  name = "Paketo Python Start Buildpack"
+  name = "Paketo Buildpack for Python Start"
 
   [[buildpack.licenses]]
     type = "Apache-2.0"


### PR DESCRIPTION
Renames 'Paketo Python Start Buildpack' to 'Paketo Buildpack for Python Start'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
