### PR TITLE
Adjust buildplan order

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -122,7 +122,7 @@ func Detect() packit.DetectFunc {
 			},
 		}
 
-		plans := []packit.BuildPlan{simplePlan, pipPlan, condaPlan, poetryInstallPlan}
+		plans := []packit.BuildPlan{pipPlan, condaPlan, poetryInstallPlan, simplePlan}
 
 		shouldReload, err := checkLiveReloadEnabled()
 		if err != nil {

--- a/detect_test.go
+++ b/detect_test.go
@@ -49,25 +49,14 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Launch: true,
 						},
 					},
-				},
-				Or: []packit.BuildPlan{
 					{
-						Provides: []packit.BuildPlanProvision{},
-						Requires: []packit.BuildPlanRequirement{
-							{
-								Name: "cpython",
-								Metadata: pythonstart.BuildPlanMetadata{
-									Launch: true,
-								},
-							},
-							{
-								Name: "site-packages",
-								Metadata: pythonstart.BuildPlanMetadata{
-									Launch: true,
-								},
-							},
+						Name: "site-packages",
+						Metadata: pythonstart.BuildPlanMetadata{
+							Launch: true,
 						},
 					},
+				},
+				Or: []packit.BuildPlan{
 					{
 						Provides: []packit.BuildPlanProvision{},
 						Requires: []packit.BuildPlanRequirement{
@@ -102,6 +91,17 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
+					{
+						Provides: []packit.BuildPlanProvision{},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "cpython",
+								Metadata: pythonstart.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+						},
+					},
 				},
 			}))
 		})
@@ -130,6 +130,12 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 						{
+							Name: "site-packages",
+							Metadata: pythonstart.BuildPlanMetadata{
+								Launch: true,
+							},
+						},
+						{
 							Name: "watchexec",
 							Metadata: pythonstart.BuildPlanMetadata{
 								Launch: true,
@@ -137,29 +143,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					Or: []packit.BuildPlan{
-						{
-							Provides: []packit.BuildPlanProvision{},
-							Requires: []packit.BuildPlanRequirement{
-								{
-									Name: "cpython",
-									Metadata: pythonstart.BuildPlanMetadata{
-										Launch: true,
-									},
-								},
-								{
-									Name: "site-packages",
-									Metadata: pythonstart.BuildPlanMetadata{
-										Launch: true,
-									},
-								},
-								{
-									Name: "watchexec",
-									Metadata: pythonstart.BuildPlanMetadata{
-										Launch: true,
-									},
-								},
-							},
-						},
 						{
 							Provides: []packit.BuildPlanProvision{},
 							Requires: []packit.BuildPlanRequirement{
@@ -194,6 +177,23 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 								},
 								{
 									Name: "poetry-venv",
+									Metadata: pythonstart.BuildPlanMetadata{
+										Launch: true,
+									},
+								},
+								{
+									Name: "watchexec",
+									Metadata: pythonstart.BuildPlanMetadata{
+										Launch: true,
+									},
+								},
+							},
+						},
+						{
+							Provides: []packit.BuildPlanProvision{},
+							Requires: []packit.BuildPlanRequirement{
+								{
+									Name: "cpython",
 									Metadata: pythonstart.BuildPlanMetadata{
 										Launch: true,
 									},


### PR DESCRIPTION
This PR adjusts the buildplan order such that the more specific buildplans come first and the least specific comes last.

The lifecycle tries buildplans in a specific order and it will stop searching for plans when it hits the first plan where all the provides & requires match up. Having the most specific plans first and least specific plans last ensures that you get a correct match.

See [Slack Thread for more details](https://paketobuildpacks.slack.com/archives/CUD6UTCJW/p1666240482044119?thread_ts=1665373426.739299&cid=CUD6UTCJW)

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
