### PR TITLE
Bump integration test timeout to 30 seconds.

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -96,7 +96,7 @@ func TestIntegration(t *testing.T) {
 		Execute(config.PoetryInstall)
 	Expect(err).NotTo(HaveOccurred())
 
-	SetDefaultEventuallyTimeout(5 * time.Second)
+	SetDefaultEventuallyTimeout(30 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)


### PR DESCRIPTION
## Summary

Bump integration test timeout to 30 seconds to reduce integration test flakes due to timeouts.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
