### PR TITLE
Revert "Add targets to buildpack.toml"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -15,11 +15,3 @@ api = "0.8"
 
 [[stacks]]
   id = "*"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "18.04"
-
-[[targets.distros]]
-name = "ubuntu"
-version = "22.04"


### PR DESCRIPTION
This reverts commit b82c41c15355b28a13394ba3cfd31f51cd6ecc3b.

 - This change was made in error. We can re-evaluate introducing targets when we bump the buildpack API spec.
