### PR TITLE
Start building and publishing multi-arch buildpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.bin
 /build
 .idea/
+/linux
+/darwin
+/windows

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Python Start Cloud Native Buildpack
-## `gcr.io/paketo-buildpacks/python`
 
 The Paketo Python Start CNB sets the start command for a given python application.
 It sets `python` as the default start command, which will start the Python REPL
 (read-eval-print loop) at launch.
+
+The buildpack is published for consumption at `paketobuildpacks/python-start`.
 
 ## Behavior
 This buildpack participates if it identifies certain python-related files (e.g.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -10,8 +10,25 @@ api = "0.8"
     uri = "https://github.com/paketo-buildpacks/python-start/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]
-  pre-package = "./scripts/build.sh"
+  include-files = [
+    "buildpack.toml",
+    "linux/amd64/bin/build",
+    "linux/amd64/bin/detect",
+    "linux/amd64/bin/run",
+    "linux/arm64/bin/build",
+    "linux/arm64/bin/detect",
+    "linux/arm64/bin/run",
+  ]
+
+  pre-package = "./scripts/build.sh --target linux/amd64 --target linux/arm64"
 
 [[stacks]]
   id = "*"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change does the following:
* Updates `buildpack.toml` to start building and publishing multi-arch buildpacks
* Add entries to `.gitignore` for multi-arch builds
* Removes references to gcr in the readme

## Use Cases
<!-- An explanation of the use cases your change enables -->
multi-arch 🥳 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
